### PR TITLE
Fix that Epic Badge list was empty

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -50,15 +50,19 @@ export function useEpics(filtered = true): { tasks: Task[] } {
         })
     }, [filtered]) as Task[]
 
-    return {
-        tasks: tasks
-            ?.sort((a, b) => {
-                return (b?.task_count ?? 0) - (a?.task_count ?? 0)
-            })
-            .filter((task) => {
-                return !!task && (task?.task_count ?? 0) > 0
-            }),
+    if (filtered) {
+        return {
+            tasks: tasks
+                ?.sort((a, b) => {
+                    return (b?.task_count ?? 0) - (a?.task_count ?? 0)
+                })
+                .filter((task) => {
+                    return !!task && (task?.task_count ?? 0) > 0
+                }),
+        }
     }
+
+    return { tasks }
 }
 
 function getWindowDimensions() {


### PR DESCRIPTION
# Summary

* Bug: The epic badge was not displaying any epics.
* Cause: The query was filtering out epics based on task count. Tasks were not loaded for epics using the unfiltered query resulting in an empty array.
* Fix: Capture filtered tasks in an if-statement and deliver unfiltered epics as-is.